### PR TITLE
- Install helm charts, and kubernetes resources in a non-default name…

### DIFF
--- a/devops-at-scale/ansible-playbooks/k8s_setup/k8s_setup_cluster.yml
+++ b/devops-at-scale/ansible-playbooks/k8s_setup/k8s_setup_cluster.yml
@@ -2,8 +2,8 @@
 
   vars:
     kubernetes_allow_pods_on_master: True
-    kubernetes_version: '1.11.0'
-    kubernetes_version_rhel_package: '1.11.0'
+    kubernetes_version: '1.13.0'
+    kubernetes_version_rhel_package: '1.13.0'
 
   environment:
     # required for join to succeed

--- a/devops-at-scale/charts/artifactory/templates/artifactory-deployment.yaml
+++ b/devops-at-scale/charts/artifactory/templates/artifactory-deployment.yaml
@@ -2,9 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}-artifactory
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -16,11 +17,11 @@ spec:
         app: {{ .Chart.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Release.Name }}-artifactory
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
-          - name: {{ .Chart.Name }}
+          - name: {{ .Release.Name }}-artifactory
             mountPath: /var/opt/jfrog/artifactory
           ports:
           - containerPort: 8081
@@ -40,11 +41,11 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
       volumes:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Release.Name }}-artifactory
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}
             claimName: "{{ .Values.persistence.existingClaim}}"
             {{ else }}
-            claimName: "{{ .Chart.Name }}-pvc"
+            claimName: "{{ .Release.Name }}-artifactory-pvc"
             {{- end -}}
 {{- end -}}

--- a/devops-at-scale/charts/artifactory/templates/artifactory-pvc.yaml
+++ b/devops-at-scale/charts/artifactory/templates/artifactory-pvc.yaml
@@ -3,7 +3,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{ .Release.Name }}-artifactory-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     trident.netapp.io/reclaimPolicy: "Retain"

--- a/devops-at-scale/charts/artifactory/templates/artifactory-svc.yaml
+++ b/devops-at-scale/charts/artifactory/templates/artifactory-svc.yaml
@@ -2,7 +2,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}-artifactory
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/devops-at-scale/charts/bitbucket/templates/bitbucket-deployment.yaml
+++ b/devops-at-scale/charts/bitbucket/templates/bitbucket-deployment.yaml
@@ -2,9 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}-bitbucket
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -16,11 +17,11 @@ spec:
         app: {{ .Chart.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Release.Name }}-bitbucket
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
-          - name: {{ .Chart.Name }}
+          - name: {{ .Release.Name }}-bitbucket
             mountPath: /var/atlassian/application-data/bitbucket
           ports:
           - containerPort: 7990
@@ -50,11 +51,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 3
       volumes:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Release.Name }}-bitbucket
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}
             claimName: "{{ .Values.persistence.existingClaim}}"
             {{ else }}
-            claimName: "{{ .Chart.Name }}-pvc"
+            claimName: "{{ .Release.Name }}-bitbucket-pvc"
             {{- end -}}
 {{- end -}}

--- a/devops-at-scale/charts/bitbucket/templates/bitbucket-pvc.yaml
+++ b/devops-at-scale/charts/bitbucket/templates/bitbucket-pvc.yaml
@@ -3,7 +3,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{ .Release.Name }}-bitbucket-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: ""
 spec:

--- a/devops-at-scale/charts/bitbucket/templates/bitbucket-svc.yaml
+++ b/devops-at-scale/charts/bitbucket/templates/bitbucket-svc.yaml
@@ -2,7 +2,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}-bitbucket-svc
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/devops-at-scale/charts/couchdb/templates/couchdb-deployment.yaml
+++ b/devops-at-scale/charts/couchdb/templates/couchdb-deployment.yaml
@@ -1,9 +1,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-couchdb
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,7 +16,7 @@ spec:
         app: {{ .Chart.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-couchdb
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
@@ -24,7 +25,7 @@ spec:
           - name: COUCHDB_PASSWORD
             value: "{{ .Values.AdminPassword }}"
           volumeMounts:
-          - name: {{ .Chart.Name }}
+          - name: {{.Release.Name}}-couchdb
             mountPath: /opt/couchdb/data
           ports:
           - containerPort: 5984
@@ -43,10 +44,10 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
       volumes:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-couchdb
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}
             claimName: "{{ .Values.persistence.existingClaim}}"
             {{ else }}
-            claimName: "{{ .Chart.Name }}-pvc"
+            claimName: "{{.Release.Name}}-couchdb-pvc"
             {{- end -}}

--- a/devops-at-scale/charts/couchdb/templates/couchdb-pvc.yaml
+++ b/devops-at-scale/charts/couchdb/templates/couchdb-pvc.yaml
@@ -2,7 +2,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{.Release.Name}}-couchdb-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     trident.netapp.io/reclaimPolicy: "Retain"

--- a/devops-at-scale/charts/couchdb/templates/couchdb-svc.yaml
+++ b/devops-at-scale/charts/couchdb/templates/couchdb-svc.yaml
@@ -1,7 +1,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-couchdb
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/devops-at-scale/charts/docker-registry/templates/configmap.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/configmap.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Chart.Name }}-config
+  name: {{.Release.Name}}-docker-registry-config
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 data:

--- a/devops-at-scale/charts/docker-registry/templates/deployment.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/deployment.yaml
@@ -2,7 +2,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  namespace: {{ .Values.global.NameSpace }}
+  name: {{.Release.Name}}-docker-registry
   labels:
     app: {{ .Chart.Name }}
 spec:
@@ -19,7 +20,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-docker-registry
           image: "{{ .Values.image }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command:
@@ -56,7 +57,7 @@ spec:
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-secret
+                  name: {{.Release.Name}}-docker-registry-secret
                   key: haSharedSecret
 {{- if .Values.tlsSecretName }}
             - name: REGISTRY_HTTP_TLS_CERTIFICATE
@@ -71,12 +72,12 @@ spec:
             - name: REGISTRY_STORAGE_S3_ACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-secret
+                  name: {{.Release.Name}}-docker-registry-secret
                   key: s3AccessKey
             - name: REGISTRY_STORAGE_S3_SECRETKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Chart.Name }}-secret
+                  name: {{.Release.Name}}-docker-registry-secret
                   key: s3SecretKey
             - name: REGISTRY_STORAGE_S3_REGION
               value: {{ required ".Values.s3.region is required" .Values.s3.region }}
@@ -101,7 +102,7 @@ spec:
             - name: data
               mountPath: /var/lib/registry/
 {{- end }}
-            - name: "{{ .Chart.Name }}-config"
+            - name: "{{.Release.Name}}-docker-registry-config"
               mountPath: "/etc/docker/registry"
 {{- if .Values.tlsSecretName }}
             - mountPath: /etc/ssl/docker
@@ -116,7 +117,7 @@ spec:
 {{- if .Values.secrets.htpasswd }}
         - name: auth
           secret:
-            secretName: {{ .Chart.Name }}-secret
+            secretName: {{.Release.Name}}-docker-registry-secret
             items:
             - key: htpasswd
               path: htpasswd
@@ -127,12 +128,12 @@ spec:
             {{- if .Values.persistence.existingClaim }}
             claimName: "{{ .Values.persistence.existingClaim}}"
             {{ else }}
-            claimName: "{{ .Chart.Name }}-pvc"
+            claimName: "{{.Release.Name}}-docker-registry-pvc"
             {{- end -}}
 {{- end }}
-        - name: {{ .Chart.Name }}-config
+        - name: {{.Release.Name}}-docker-registry-config
           configMap:
-            name: {{ .Chart.Name }}-config
+            name: {{.Release.Name}}-docker-registry-config
 {{- if .Values.tlsSecretName }}
         - name: tls-cert
           secret:

--- a/devops-at-scale/charts/docker-registry/templates/docker-registry-pvc.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/docker-registry-pvc.yaml
@@ -3,7 +3,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{.Release.Name}}-docker-registry-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: ""
 spec:
@@ -14,6 +15,6 @@ spec:
       storage: "{{ .Values.persistence.ontap.volumeSize }}"
   selector:
     matchLabels:
-      netapp-use: "{{ .Chart.Name }}-vol"
+      netapp-use: "{{.Release.Name}}-docker-registry-vol"
 {{- end -}}
 {{- end -}}

--- a/devops-at-scale/charts/docker-registry/templates/ingress.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/devops-at-scale/charts/docker-registry/templates/secret.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Chart.Name }}-secret
+  name: {{.Release.Name}}-docker-registry-secret
   labels:
     app: {{ .Chart.Name }}
 type: Opaque

--- a/devops-at-scale/charts/docker-registry/templates/service.yaml
+++ b/devops-at-scale/charts/docker-registry/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-docker-registry
   labels:
     app: {{ .Chart.Name }}
 {{- if .Values.service.annotations }}

--- a/devops-at-scale/charts/gitlab/templates/gitlab-deployment.yaml
+++ b/devops-at-scale/charts/gitlab/templates/gitlab-deployment.yaml
@@ -2,9 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-gitlab
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -16,14 +17,14 @@ spec:
         app: {{ .Chart.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-gitlab
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
           - name: GITLAB_ROOT_PASSWORD
             value: "{{ .Values.AdminPassword }}"
           volumeMounts:
-          - name: {{ .Chart.Name }}
+          - name: {{.Release.Name}}-gitlab
             mountPath: /var/opt/gitlab
           ports:
           - containerPort: 80
@@ -50,11 +51,11 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
       volumes:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-gitlab
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}
             claimName: "{{ .Values.persistence.existingClaim}}"
             {{ else }}
-            claimName: "{{ .Chart.Name }}-pvc"
+            claimName: "{{.Release.Name}}-gitlab-pvc"
             {{- end -}}
 {{- end -}}

--- a/devops-at-scale/charts/gitlab/templates/gitlab-pvc.yaml
+++ b/devops-at-scale/charts/gitlab/templates/gitlab-pvc.yaml
@@ -3,7 +3,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{.Release.Name}}-gitlab-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     trident.netapp.io/reclaimPolicy: "Retain"

--- a/devops-at-scale/charts/gitlab/templates/gitlab-svc.yaml
+++ b/devops-at-scale/charts/gitlab/templates/gitlab-svc.yaml
@@ -2,7 +2,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-gitlab
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/devops-at-scale/charts/gitlab/templates/gitlab-test.yaml
+++ b/devops-at-scale/charts/gitlab/templates/gitlab-test.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-gitlab-tests-{{ randAlphaNum 5 | lower }}"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/devops-at-scale/charts/jenkins/templates/config.yaml
+++ b/devops-at-scale/charts/jenkins/templates/config.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ .Values.global.NameSpace }}
 data:
   config.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>
@@ -33,6 +34,7 @@ data:
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
               <name>default</name>
+              <namespace>{{ .Values.global.NameSpace }}</namespace>
               <instanceCap>2147483647</instanceCap>
               <idleMinutes>0</idleMinutes>
               <label>{{ .Release.Name }}-{{ .Values.Agent.Component }}</label>
@@ -74,7 +76,7 @@ data:
                   <envVars>
                     <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                       <key>JENKINS_URL</key>
-                      <value>http://{{.Chart.Name}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+                      <value>http://{{.Release.Name}}-jenkins:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
                     </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                   </envVars>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
@@ -96,9 +98,9 @@ data:
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>
-          <namespace>{{ .Release.Namespace }}</namespace>
-          <jenkinsUrl>http://{{.Chart.Name}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
-          <jenkinsTunnel>{{.Chart.Name}}-agent:50000</jenkinsTunnel>
+          <namespace>{{ .Values.global.NameSpace }}</namespace>
+          <jenkinsUrl>http://{{.Release.Name}}-jenkins:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+          <jenkinsTunnel>{{.Release.Name}}-jenkins-agent:50000</jenkinsTunnel>
           <containerCap>1000</containerCap>
           <retentionTimeout>5</retentionTimeout>
           <connectTimeout>0</connectTimeout>

--- a/devops-at-scale/charts/jenkins/templates/jenkins-agent-svc.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-agent-svc.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-agent
+  name: {{.Release.Name}}-jenkins-agent
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/devops-at-scale/charts/jenkins/templates/jenkins-master-deployment.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-master-deployment.yaml
@@ -1,7 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-jenkins
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -209,7 +210,7 @@ spec:
           {{- if .Values.persistence.existingClaim }}
           claimName: "{{ .Values.persistence.existingClaim}}"
           {{ else }}
-          claimName: "{{ .Chart.Name }}-pvc"
+          claimName: "{{.Release.Name}}-jenkins-pvc"
           {{- end -}}
       {{- else }}
         emptyDir: {}

--- a/devops-at-scale/charts/jenkins/templates/jenkins-master-ingress.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-master-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ toYaml .Values.Master.Ingress.Annotations | indent 4 }}
 {{- end }}
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ .Values.global.NameSpace }}
 spec:
   rules:
   - host: {{ .Values.Master.HostName | quote }}

--- a/devops-at-scale/charts/jenkins/templates/jenkins-master-networkpolicy.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-master-networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
 metadata:
   name: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  namespace: {{ .Values.global.NameSpace }}
 spec:
   podSelector:
     matchLabels:

--- a/devops-at-scale/charts/jenkins/templates/jenkins-master-svc.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-master-svc.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-jenkins
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
     heritage: {{.Release.Service | quote }}

--- a/devops-at-scale/charts/jenkins/templates/jenkins-pvc.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-pvc.yaml
@@ -2,7 +2,8 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "{{ .Chart.Name }}-pvc"
+  name: "{{.Release.Name}}-jenkins-pvc"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     volume.beta.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     trident.netapp.io/reclaimPolicy: "Retain"

--- a/devops-at-scale/charts/jenkins/templates/jenkins-test.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jenkins-test.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  namespace: {{ .Values.global.NameSpace }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/devops-at-scale/charts/jenkins/templates/jobs.yaml
+++ b/devops-at-scale/charts/jenkins/templates/jobs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}-jobs
+  namespace: {{ .Values.global.NameSpace }}
 data:
 {{ .Values.Master.Jobs | indent 2 }}
 {{- end -}}

--- a/devops-at-scale/charts/jenkins/templates/rbac.yaml
+++ b/devops-at-scale/charts/jenkins/templates/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersi
 kind: ClusterRoleBinding
 metadata:
   name: {{ $serviceName }}-role-binding
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ $serviceName }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -16,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ $serviceName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.NameSpace }}
 {{ end }}

--- a/devops-at-scale/charts/jenkins/templates/secret.yaml
+++ b/devops-at-scale/charts/jenkins/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ template "jenkins.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/devops-at-scale/charts/jenkins/templates/service-account.yaml
+++ b/devops-at-scale/charts/jenkins/templates/service-account.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $serviceName }}
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ $serviceName }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/devops-at-scale/charts/jenkins/templates/test-config.yaml
+++ b/devops-at-scale/charts/jenkins/templates/test-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}-tests
+  namespace: {{ .Values.global.NameSpace }}
 data:
   run.sh: |-
     @test "Testing Jenkins UI is accessible" {

--- a/devops-at-scale/charts/webservice/templates/webservice-deployment.yaml
+++ b/devops-at-scale/charts/webservice/templates/webservice-deployment.yaml
@@ -1,9 +1,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-webservice
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -14,20 +15,50 @@ spec:
       labels:
         app: {{ .Chart.Name }}
     spec:
-      serviceAccountName: {{ .Chart.Name }}
+      serviceAccountName: {{.Release.Name}}-webservice
       imagePullSecrets:
         - name: buildatscaleregcred
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{.Release.Name}}-webservice
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
+          # SCM specs
           - name: SCM_TYPE
             value: "{{ .Values.global.scm.type }}"
+          - name: SCM_SERVICE_NAME
+            value: "{{ .Release.Name }}-{{ .Values.global.scm.type }}"
+          - name: SCM_PVC_NAME
+            value: "{{ .Release.Name }}-{{ .Values.global.scm.type }}-pvc"
+          # Jenkins specs
+          - name: JENKINS_SERVICE_NAME
+            value: "{{ .Release.Name }}-jenkins"
+          - name: JENKINS_PVC_NAME
+            value: "{{ .Release.Name }}-jenkins-pvc"
+          # CouchDB specs
+          - name: DATABASE_SERVICE_NAME
+            value: "{{ .Release.Name }}-couchdb"
+          - name: DATABASE_PVC_NAME
+            value: "{{ .Release.Name }}-couchdb-pvc"
+          # Artifactory specs
+          - name: REGISTRY_SERVICE_NAME
+            value: "{{ .Release.Name }}-{{ .Values.global.registry.type }}"
+          - name: REGISTRY_PVC_NAME
+            value: "{{ .Release.Name }}-{{ .Values.global.registry.type }}-pvc"
           - name: REGISTRY_TYPE
             value: "{{ .Values.global.registry.type }}"
+          # Webservice specs
+          - name: WEB_SERVICE_NAME
+            value: "{{ .Release.Name }}-webservice"
+          - name: WEB_PVC_NAME
+            value: "{{ .Release.Name }}-webservice-pvc"
+          # Kube specs
           - name: SERVICE_TYPE
             value: "{{ .Values.global.ServiceType }}"
+          - name: KUBE_NAMESPACE
+            value: "{{ .Values.global.NameSpace }}"
+          - name: STORAGE_CLASS
+            value: "{{ .Values.StorageClass }}"
           ports:
           - containerPort: 80
             name: http
@@ -39,13 +70,13 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 180
-            failureThreshold: 200
-            periodSeconds: 10
+            initialDelaySeconds: 600
+            failureThreshold: 600
+            periodSeconds: 40
           readinessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 180
-            periodSeconds: 10
-            failureThreshold: 200
+            initialDelaySeconds: 600
+            periodSeconds: 40
+            failureThreshold: 600

--- a/devops-at-scale/charts/webservice/templates/webservice-rbac.yaml
+++ b/devops-at-scale/charts/webservice/templates/webservice-rbac.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Chart.Name }}-role-binding
+  name: {{.Release.Name}}-webservice
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 roleRef:
@@ -10,5 +11,5 @@ roleRef:
   name: cluster-admin 
 subjects:
 - kind: ServiceAccount
-  name: {{ .Chart.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{.Release.Name}}-webservice
+  namespace: {{ .Values.global.NameSpace }}

--- a/devops-at-scale/charts/webservice/templates/webservice-service-account.yaml
+++ b/devops-at-scale/charts/webservice/templates/webservice-service-account.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-webservice
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}

--- a/devops-at-scale/charts/webservice/templates/webservice-svc.yaml
+++ b/devops-at-scale/charts/webservice/templates/webservice-svc.yaml
@@ -1,7 +1,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{.Release.Name}}-webservice
+  namespace: {{ .Values.global.NameSpace }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/devops-at-scale/charts/webservice/values.yaml
+++ b/devops-at-scale/charts/webservice/values.yaml
@@ -1,3 +1,4 @@
 replicaCount: 1
-image:  archana51189/devops-at-scale:1.1
+image: archana51189/devops-at-scale:1.2
 imagePullPolicy: Always
+StorageClass: "basic"

--- a/devops-at-scale/templates/NOTES.txt
+++ b/devops-at-scale/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thanks for using Build@Scale!
+Thanks for using DevOps@Scale!
 
 Please wait for all pods/services to reach the 'ready' state prior to using
 
@@ -9,13 +9,13 @@ Once all pods are ready , please follow the steps below to get started.
 
 If using the NodePort(default) service type:
 
-	export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
-	export SERVICE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{.Release.Name}}-webservice)
+	export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}" -n {{.Values.global.NameSpace}})
+	export SERVICE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" -n {{.Values.global.NameSpace}} services {{.Release.Name}}-webservice)
 	export SERVICE_URL=$NODE_IP:$SERVICE_PORT
 
-	Then visit the $SERVICE_URL using your web browser to begin using Build@Scale
+	Then visit the $SERVICE_URL using your web browser to begin using DevOps@Scale
 
-If using the LoadBalancer service type , set $SERVICE_URL to the EXTERNAl_IP of 'devops-at-scale-webservice'
+If using the LoadBalancer service type , set $SERVICE_URL to the EXTERNAl_IP of '{{.Release.Name}}-webservice'
 
 
 2) Then visit the $SERVICE_URL using your web browser to begin using DevOps@Scale

--- a/devops-at-scale/values.yaml
+++ b/devops-at-scale/values.yaml
@@ -1,19 +1,16 @@
 global:
   # "LoadBalancer" or "NodePort"
   ServiceType: NodePort
+  # Kubernetes Namespace
+  NameSpace: default 
   scm:
     # "gitlab" or "bitbucket"
     type: "gitlab"
   registry:
     # "artifactory" or "docker-registry"
     type: "artifactory"
+  version: 1.2
   persistence:
     ontap:
-      # If set to "true", ontap volumes for various services(E.g. gitlab/aritifactory/couchdb) will be automatically created
-      automaticVolumeCreation: false
       # ontap data lif IP address
       dataIP: ""
-      # ontap SVM/Vserver
-      svm: ""
-      # ontap aggregate
-      aggregate: ""


### PR DESCRIPTION
…space

- Use Kube 1.13 for kubernetes setup using Ansible
- Use helm release-name as a prefix for all Kubernetes resource names
- This commit is tested to deploy the solution in a specific non-default Kube namespace and hence multiple deployments can be madeacross different namespaces using the same chart but different helm release-names