### PR TITLE
Backend logic to support namespacing and storage class isolation

### DIFF
--- a/web_service/web_service/backend/tests/test_views.py
+++ b/web_service/web_service/backend/tests/test_views.py
@@ -5,7 +5,6 @@ import sys
 import unittest
 from unittest.mock import patch, Mock
 from web_service import create_app
-from web_service.helpers.errors import GenericException
 
 # Set project root directory so coverage.py can generate coverage
 BASE_DIR = os.path.join(os.path.dirname(__file__), '../..')
@@ -20,6 +19,7 @@ class ViewsTestCase(unittest.TestCase):
         with self.app.app_context():
             self.app.testing = True
         self.client = self.app.test_client()
+        # KubernetesAPI({'namespace': 'test', 'service_type': 'test_svc'})
 
     def tearDown(self):
         pass
@@ -32,14 +32,16 @@ class ViewsTestCase(unittest.TestCase):
         # assert the status code of the response
         self.assertEqual(response.status_code, 200)
 
-    def test_index_backend(self):
+    @patch('web_service.helpers.helpers._setup_couchdb')
+    def test_index_backend(self, mock_setup):
         ''' Test index response with endpoint 'backend' '''
         response = self.client.get("/backend/")
         # assert the status code of the response
         self.assertEqual(response.status_code, 200)
 
     @patch('web_service.ontap.ontap_service.OntapService.get_snapshot_list')
-    def test_snapshot_list(self, mock_get_snapshot_list):
+    @patch('web_service.helpers.helpers._setup_couchdb')
+    def test_snapshot_list(self, mock_setup, mock_get_snapshot_list):
         ''' Test list snapshots endpoint '''
         mock_get_snapshot_list.return_value = ["test_snapshot_name_1"], None
         # TODO: missing endpoint
@@ -50,18 +52,16 @@ class ViewsTestCase(unittest.TestCase):
         # self.assertEqual(mock_get_snapshot_list.return_value[0], data)
 
     # TODO: revisit @setup_required in frontend and backend
+    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_instance')
     @patch('web_service.helpers.helpers._setup_couchdb')
     @patch('web_service.helpers.helpers.get_db_config')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.__init__')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.create_pvc_clone_resource')
     @patch('web_service.helpers.helpers.connect_db')
     @patch('web_service.database.snapshot.Snapshot.store')
-    def test_build_snapshot_create(self, mock_snapshot_store, mock_connect_db, mock_create_pvc_clone,
-                                   mock_kube, mock_get_db_config, mock_setup):
+    def test_build_snapshot_create(self, mock_snapshot_store, mock_connect_db,
+                                   mock_get_db_config, mock_setup, mock_kube):
         ''' Test create volumeclaim endpoint '''
         pvc_clone_name = 'test_pvc_clone_name'
-        mock_kube.return_value = None
-        mock_create_pvc_clone.return_value = [
+        mock_kube.return_value.create_pvc_clone_resource.return_value = [
             {
                 "code": 201,
                 "error_message": "",
@@ -82,29 +82,6 @@ class ViewsTestCase(unittest.TestCase):
         data = json.loads(response.data)[0]    # response is single JSON object enclosed in a list
         self.assertEqual(data['resource_name'], pvc_clone_name)
 
-    @patch('web_service.ontap.ontap_service.OntapService.delete_snapshot')
-    def test_snapshot_delete(self, mock_delete_snapshot):
-        ''' Test delete snapshot endpoint '''
-        snapshot_name = 'test_create_snapshot'
-        mock_delete_snapshot.return_value = [
-            {
-                "code": 201,
-                "error_message": "",
-                "message": "Snapshot %s completed successfully" % snapshot_name,
-                "resource": "Snapshot",
-                "resource_name": snapshot_name,
-                "status": "COMPLETED"
-            }
-        ]
-        # TODO: missing endpoint
-        response = self.client.delete("/backend/snapshot/delete",
-                                      data=dict(volume_name='test_volume',
-                                                snapshot_name=snapshot_name))
-        self.assertEqual(response.status_code, 404)
-        # data = json.loads(response.data)[0]    # response is single JSON object enclosed in a list
-        # self.assertEqual(data['resource_name'], snapshot_name)
-
-    # TODO: revisit @setup_required in frontend and backend
     @patch('web_service.helpers.helpers._setup_couchdb')
     @patch('web_service.helpers.helpers.get_db_config')
     def test_snapshot_bad_request(self, mock_get_db_config, mock_setup):
@@ -113,26 +90,22 @@ class ViewsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @patch('web_service.jenkins.jenkins_api_secure.j.jenkins.Jenkins')
-    # TODO: revisit @setup_required in frontend and backend
     @patch('web_service.helpers.helpers._setup_couchdb')
     @patch('web_service.helpers.helpers.connect_db')            # for _get_config_from_db
     @patch('web_service.helpers.helpers.get_db_config')         # for _get_config_from_db
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.__init__')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.create_pvc_resource')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_volume_name_from_pvc')
+    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_instance')
     @patch('web_service.jenkins.jenkins_api_secure.JenkinsAPI.create_job')
-    def test_project_creation(self, mock_jenkins_api, mock_kb_get_vol, mock_kubernetes_api, mock_kube,
-                              mock_get_db_config, mock_db_connect, mock_setup, mock_jenkins):
+    def test_pipeline_creation(self, mock_jenkins_api, mock_kube,
+                               mock_get_db_config, mock_db_connect, mock_setup, mock_jenkins):
         '''Test project creation endpoint'''
         mock_get_db_config.return_value = {'jenkins_url': 'test', 'jenkins_user': 'test',
                                            'jenkins_pass': 'test', 'scm_volume': '',
                                            'web_service_username': '', 'web_service_password': '',
                                            'web_service_url': '', 'registry_service_name': '',
-                                           'scm_pvc_name': 'test'}
-        mock_kube.return_value = None
-        mock_kb_get_vol.return_value = 'test_volume_name'
+                                           'scm_pvc_name': 'test', 'kube_namespace': 'test'}
+        mock_kube.return_value.get_volume_name_from_pvc.return_value = 'test_volume_name'
         mock_jenkins_api.return_value = True
-        mock_kubernetes_api.return_value = {
+        mock_kube.return_value.create_pvc_resource.return_value = {
             'name': 'test-1-pvc', 'status': 'COMPLETED', 'code': 201,
             'message': 'PVC test-1-pvc created successfully', 'error': '', 'resource': 'PVC'
         }
@@ -145,29 +118,26 @@ class ViewsTestCase(unittest.TestCase):
         print(resp.get_data(as_text=True))
         self.assertEqual(resp.status_code, 200)
 
-    # TODO: revisit @setup_required in frontend and backend
     @patch('web_service.helpers.helpers._setup_couchdb')
     @patch('web_service.helpers.helpers.connect_db')            # for _get_config_from_db
     @patch('web_service.helpers.helpers.get_db_config')         # for _get_config_from_db
     @patch('web_service.database.workspace.exceeded_workspace_count_for_user')
     @patch('web_service.helpers.helpers.get_db_user_document')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.__init__')
-    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.create_pvc_and_pod')
+    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_instance')
     @patch('time.sleep')                                        # to avoid sleeping for a minute
     @patch('web_service.kub.KubernetesAPI.KubernetesAPI.execute_command_in_pod')
     @patch('web_service.database.workspace.Workspace.store')
-    def test_workspace_creation(self, mock_store, mock_kube_exec, mock_sleep, mock_create_pvc_pod,
+    def test_workspace_creation(self, mock_store, mock_kube_exec, mock_sleep,
                                 mock_kube, mock_get_db_user_doc, mock_exceeded, mock_get_db_config,
                                 mock_connect_db, mock_setup_couch_db):
         '''Test workspace creation endpoint'''
         config = {
             'user_workspace_limit': 10,
             'workspace_pod_image': 'test_pod_image',
-            'services_type': 'what is this for?'
+            'service_type': 'what is this for?'
         }
         mock_get_db_config.return_value = config
         mock_exceeded.return_value = [False, []]
-        mock_kube.return_value = None
         mock_create_pvc_pod_return_value = [
             {'code': 201, 'resource': 'PVC', 'status': 'COMPLETED',
              'resource_name': 'test-clone-pvc',
@@ -184,9 +154,10 @@ class ViewsTestCase(unittest.TestCase):
             workspace['pvc'] = 'test_pvc_name'
             workspace['pv_name'] = 'test_pv_name'
             workspace['service'] = 'test_service_name'
+            workspace['pipeline_pvc'] = 'test_pvc_name'
             return mock_create_pvc_pod_return_value
 
-        mock_create_pvc_pod.side_effect = update_worskspace
+        mock_kube.return_value.create_pvc_clone_and_pod.side_effect = update_worskspace
 
         new_workspace_data = {
             'workspace-name': 'test',
@@ -200,26 +171,9 @@ class ViewsTestCase(unittest.TestCase):
         response = self.client.post("/backend/workspace/create", data=new_workspace_data)
         self.assertEqual(response.status_code, 200)
 
-    @patch('web_service.helpers.helpers.get_db_config')
-    @patch('web_service.database.snapshot.Snapshot')
-    @patch('web_service.database.snapshot.purge')
-    def test_snapshot_purge(self, mock_snapshot_purge, mock_snapshot, mock_db_connect):
-        '''Test snapshots purge endpoint'''
-        # TODO: not implemented yet /backend/build/purge ?
-        response = self.client.post("/backend/snapshot/purge")
-        self.assertEqual(response.status_code, 404)
-
-    @patch('web_service.helpers.helpers.get_db_config')
-    @patch('web_service.database.snapshot.Snapshot')
-    @patch('web_service.database.snapshot.purge')
-    def test_snapshot_purge_fail(self, mock_snapshot_purge, mock_snapshot, mock_db_connect):
-        '''Test snapshots purge exception'''
-        # TODO: not implemented yet /backend/build/purge ?
-        response = self.client.post("/backend/snapshot/purge", data={'type': 'invalid'})
-        self.assertEqual(response.status_code, 404)
-
+    @patch('web_service.helpers.helpers.onetime_setup_required')
     @patch('web_service.database.workspace.purge_old_workspaces')
-    def test_workspace_purge(self, mock_purge_workspace):
+    def test_workspace_purge(self, mock_purge_workspace, mock_setup):
         '''Test purge workspaces endpoint'''
         mock_purge_workspace.return_value = 1, ['deleted_ws_1']
         response = self.client.post("/backend/workspace/purge")
@@ -227,7 +181,6 @@ class ViewsTestCase(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(len(data['purged_workspaces']), 1)
 
-    # TODO: revisit @setup_required in frontend and backend
     @patch('web_service.helpers.helpers._setup_couchdb')
     @patch('web_service.helpers.helpers.connect_db')            # for _get_config_from_db
     @patch('web_service.helpers.helpers.get_db_config')         # for _get_config_from_db
@@ -243,3 +196,43 @@ class ViewsTestCase(unittest.TestCase):
         mock_exceeded_limit.return_value = True, None
         response = self.client.post("/backend/workspace/create", data=workspace_data)
         self.assertEqual(response.status_code, 401)
+
+    # TODO: To be replaced with /backend/buildclone/purge
+    # @patch('web_service.helpers.helpers.get_db_config')
+    # @patch('web_service.database.snapshot.Snapshot')
+    # @patch('web_service.database.snapshot.purge')
+    # def test_snapshot_purge(self, mock_snapshot_purge, mock_snapshot, mock_db_connect):
+    #     '''Test snapshots purge endpoint'''
+    #     response = self.client.post("/backend/snapshot/purge")
+    #     self.assertEqual(response.status_code, 404)
+
+    #     # TODO: To be replaced with /backend/buildclone/purge
+    # @patch('web_service.helpers.helpers.get_db_config')
+    # @patch('web_service.database.snapshot.Snapshot')
+    # @patch('web_service.database.snapshot.purge')
+    # def no_test_snapshot_purge_fail(self, mock_snapshot_purge, mock_snapshot, mock_db_connect):
+    #     '''Test snapshots purge exception'''
+    #     response = self.client.post("/backend/snapshot/purge", data={'type': 'invalid'})
+    #     self.assertEqual(response.status_code, 404)
+
+    #     # TODO: missing endpoint -- to be replaced with /backend/buildclone/delete
+    # @patch('web_service.ontap.ontap_service.OntapService.delete_snapshot')
+    # def test_snapshot_delete(self, mock_delete_snapshot):
+    #     ''' Test delete snapshot endpoint '''
+    #     snapshot_name = 'test_create_snapshot'
+    #     mock_delete_snapshot.return_value = [
+    #         {
+    #             "code": 201,
+    #             "error_message": "",
+    #             "message": "Snapshot %s completed successfully" % snapshot_name,
+    #             "resource": "Snapshot",
+    #             "resource_name": snapshot_name,
+    #             "status": "COMPLETED"
+    #         }
+    #     ]
+    #     response = self.client.delete("/backend/snapshot/delete",
+    #                                   data=dict(volume_name='test_volume',
+    #                                             snapshot_name=snapshot_name))
+    #     self.assertEqual(response.status_code, 404)
+    #     # data = json.loads(response.data)[0]    # response is single JSON object enclosed in a list
+    #     # self.assertEqual(data['resource_name'], snapshot_name)

--- a/web_service/web_service/backend/tests/test_views.py
+++ b/web_service/web_service/backend/tests/test_views.py
@@ -19,7 +19,6 @@ class ViewsTestCase(unittest.TestCase):
         with self.app.app_context():
             self.app.testing = True
         self.client = self.app.test_client()
-        # KubernetesAPI({'namespace': 'test', 'service_type': 'test_svc'})
 
     def tearDown(self):
         pass

--- a/web_service/web_service/backend/views.py
+++ b/web_service/web_service/backend/views.py
@@ -413,7 +413,6 @@ def workspace_purge():
 
     """
     count, purged_workspaces = workspace_obj.purge_old_workspaces()
-    print("Got count and purged_workspaces", str(count))
     response = {'code': 200,
                 'resource': 'purge',
                 'customer_instance': app.config['DATABASE_NAME'],

--- a/web_service/web_service/database/configuration.py
+++ b/web_service/web_service/database/configuration.py
@@ -27,26 +27,32 @@ class Configuration(Document):
 
     # JENKINS
     jenkins_service_name = TextField()
+    jenkins_pvc_name = TextField()
     jenkins_url = TextField()
     jenkins_user = TextField(default="admin")
     jenkins_pass = TextField(default="admin")
 
     # Database CouchDB
     database_service_name = TextField()
+    database_pvc_name = TextField()
 
     # Artifactory
     registry_service_name = TextField()
+    registry_pvc_name = TextField()
     registry_type = TextField(default="artifactory")
 
     # Webservice
     web_service_name = TextField()
+    web_pvc_name = TextField()
     web_service_url = TextField()
     web_service_username = TextField(default="admin")
     web_service_password = TextField(default="admin")
 
-    # Others
-    services_type = TextField(default='NodePort')
-    devops_at_scale_version = TextField(default='1.1')
+    # Kube specifics
+    service_type = TextField()
+    kube_namespace = TextField(default='default')
+    devops_at_scale_version = TextField(default='1.2')
+    storage_class = TextField()
 
     # User Workspace
     workspace_pod_image = TextField(default="theiaide/theia-python:0.4.0-next.6243fc63")

--- a/web_service/web_service/database/snapshot.py
+++ b/web_service/web_service/database/snapshot.py
@@ -12,6 +12,8 @@ class Snapshot(Document):
     name = TextField()
     type = TextField(default="snapshot")
     volume = TextField()
+    pvc = TextField()
+    parent_pipeline_pvc = TextField()
     project = TextField()
     jenkins_build = IntegerField()
     build_status = TextField()

--- a/web_service/web_service/database/workspace.py
+++ b/web_service/web_service/database/workspace.py
@@ -17,6 +17,7 @@ class Workspace(Document):
     build_name = TextField()
     pvc = TextField()
     source_pvc = TextField()
+    pipeline_pvc = TextField()
     service = TextField()
     pod = TextField()
     pv = TextField()

--- a/web_service/web_service/frontend/views.py
+++ b/web_service/web_service/frontend/views.py
@@ -14,7 +14,6 @@ app = Flask(__name__)
 
 @frontend_blueprint.before_app_first_request
 def setup():
-    print("Before First request, calling one time couchDB setup")
     helpers.onetime_setup_required()
 
 
@@ -55,7 +54,6 @@ def create_project():
 
 
 @frontend_blueprint.route('/frontend/workspace/git-projects', methods=['GET'])
-@helpers.setup_required
 def get_projects():
     try:
         projects = helpers.get_git_projects()

--- a/web_service/web_service/helpers/test_helpers.py
+++ b/web_service/web_service/helpers/test_helpers.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, Mock
+import web_service.helpers.helpers as ut
+
+# Set project root directory so coverage.py can generate coverage
+BASE_DIR = os.path.join(os.path.dirname(__file__), '../..')
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
+
+class TestHelpersMethods(unittest.TestCase):
+    """ Test Kubernetes API """
+
+    def setUp(self):
+        pass
+
+    @patch('web_service.helpers.helpers._setup_couchdb')
+    def test_onetime_setup(self, mock_setup):
+        """ Test helper to call setup_couchdb once """
+        ut.onetime_setup_required()
+        mock_setup.assert_called_once_with()

--- a/web_service/web_service/jenkins/jenkins_api_secure.py
+++ b/web_service/web_service/jenkins/jenkins_api_secure.py
@@ -139,10 +139,9 @@ class JenkinsAPI(object):
         """ Create Jenkins job template, setup build parameters """
         template_loader = jinja2.FileSystemLoader(searchpath="./web_service/templates/")
         template_env = jinja2.Environment(loader=template_loader)
-
         if params['type'] == 'ci-pipeline':
 
-            template_file = "./ci_pipeline.xml"
+            template_file = "ci_pipeline.xml"
 
             job_template_vars = {
                 "SOURCE_CODE_BRANCH": form_fields['scm-branch'],
@@ -152,14 +151,16 @@ class JenkinsAPI(object):
                 "CONTAINER_REGISTRY": params['registry_service_name'],
                 "SCM_VOLUME": params['scm_volume'],
                 "SCM_VOLUME_CLAIM": params['scm_pvc_name'],
-                "WEB_SERVICE_URL": params['web_service_url']
+                "WEB_SERVICE_URL": params['web_service_url'],
+                "KUBE_NAMESPACE": params['kube_namespace']
             }
         elif params['type'] == 'trigger-purge':
             template_file = "./purge_policy_enforcer_job.xml"
             job_template_vars = {
                 "SERVICE_URL": params['web_service_url'],
                 "SERVICE_USERNAME": params['web_service_username'],
-                "SERVICE_PASSWORD": params['web_service_password']
+                "SERVICE_PASSWORD": params['web_service_password'],
+                "KUBE_NAMESPACE": params['kube_namespace']
             }
         else:
             raise KeyError

--- a/web_service/web_service/kub/test_kubernetes_api.py
+++ b/web_service/web_service/kub/test_kubernetes_api.py
@@ -17,9 +17,12 @@ if BASE_DIR not in sys.path:
 
 class TestKubernetesAPIMethods(unittest.TestCase):
     """ Test Kubernetes API """
+
+    @classmethod
     @patch('kubernetes.config.load_kube_config')
-    def setUp(self, mock_load_config):
-        self.kube_api = ut.KubernetesAPI("12345", "abcdef")
+    def setUpClass(self, mock_load_config):
+        kube = ut.KubernetesAPI({'namespace': "12345", 'service_type': "abcdef"})
+        self.kube_api = kube.get_instance()
 
     def test_create_pv_config(self):
         """ Test helper to create config dictionary """
@@ -107,41 +110,42 @@ class TestKubernetesAPIMethods(unittest.TestCase):
         attempted_status = ontap.set_status(400, 'Volume', 'test-vol', 'Error creating PV')
         self.assertEqual(expected_status, attempted_status)
 
-    # disable unit test until mock bug is fixed
-    # @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_worker_node')
-    # @patch('kubernetes.client.CoreV1Api.read_namespaced_service')
-    # def test_get_service_url(
-    #         self, mock_read_namespaced_service, mock_get_worker_node):
-    #     """Test get_service_url function """
-    #     mock_node = "kube-worker-node-01.devops.com"
-    #     mock_get_worker_node.return_value = mock_node
-    #     mock_read_namespaced_service.return_value = {
-    #         'api_version': 'v1',
-    #         'kind': 'Service',
-    #         'metadata': {'annotations': None,
-    #                      'cluster_name': None,
-    #                      'labels': {'component': 'apiserver', 'provider': 'kubernetes'},
-    #                      'name': 'kubernetes',
-    #                      'namespace': 'default',
-    #                      'owner_references': None,
-    #                      'resource_version': '91',
-    #                      'self_link': '/api/v1/namespaces/default/services/kubernetes',
-    #                      'uid': '47ce8895-d941-11e7-ba12-00505693776b'},
-    #         'spec': {'cluster_ip': '10.96.0.1',
-    #                  'external_i_ps': None,
-    #                  'ports': [{'name': 'https',
-    #                             'node_port': 31455,
-    #                             'port': 443,
-    #                             'protocol': 'TCP',
-    #                             'target_port': 6443}],
-    #                  'publish_not_ready_addresses': None,
-    #                  'selector': None,
-    #                  'session_affinity': 'ClientIP',
-    #                  'session_affinity_config': {'client_ip': {'timeout_seconds': 10800}},
-    #                  'type': 'ClusterIP'},
-    #         'status': {'load_balancer': {'ingress': None}}
-    #     }
-    #
-    #     service_name = 'kubernetes'
-    #     result = self.kube_api.get_service_url(service_name)
-    #     self.assertEqual(result, "%s:%s" % (mock_node, "31455"))
+    @patch('web_service.kub.KubernetesAPI.KubernetesAPI.get_worker_node')
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_service')
+    def test_get_service_url(self, mock_read_ns_service, mock_get_worker_node):
+        """Test get_service_url function """
+        mock_node = "kube-worker-node-01.devops.com"
+        mock_service = Mock(api_version='v1')
+        mock_service.spec = Mock(ports=[Mock(node_port=31455)])
+        mock_get_worker_node.return_value = mock_node
+        attrs = {
+            'api_version': 'v1',
+            'kind': 'Service',
+            'metadata': {'annotations': None,
+                         'cluster_name': None,
+                         'labels': {'component': 'apiserver', 'provider': 'kubernetes'},
+                         'name': 'kubernetes',
+                         'namespace': 'default',
+                         'owner_references': None,
+                         'resource_version': '91',
+                         'self_link': '/api/v1/namespaces/default/services/kubernetes',
+                         'uid': '47ce8895-d941-11e7-ba12-00505693776b'},
+            'spec': {'cluster_ip': '10.96.0.1',
+                     'external_i_ps': None,
+                     'ports': [{'name': 'https',
+                                'node_port': 31455,
+                                'port': 443,
+                                'protocol': 'TCP',
+                                'target_port': 6443}],
+                     'publish_not_ready_addresses': None,
+                     'selector': None,
+                     'session_affinity': 'ClientIP',
+                     'session_affinity_config': {'client_ip': {'timeout_seconds': 10800}},
+                     'type': 'ClusterIP'},
+            'status': {'load_balancer': {'ingress': None}}
+        }
+        mock_read_ns_service.return_value = mock_service
+
+        service_name = 'kubernetes'
+        result = self.kube_api.get_service_url(service_name)
+        self.assertEqual(result, "http://%s:%s" % (mock_node, "31455"))


### PR DESCRIPTION
Changes to web_service/backend:
- Delete pipelines iff there are no workspaces associated with the pipeline. Delete build clones before deleting the pipeline
Changes to web_service/database:
- Store PVC names for clone and workspace to be used when deleting pipelines

Changes to web_service/kub:
- KubernetesAPI class maintains a singleton instance pattern — since each deployment is tied to a single namespace, we will use a single instance of the API class to perform all the resource operations
- Namespace, storage-class (for web service) and service-type are globally set in configuration to be passed onto the Kube instance
- When storage class is not set by the user, allow PVC to be created in default Storage class defined in Kubernetes cluster
- Update Kube unit tests to reflect singleton instance for KubernetesAPI class

Changes to web_service/frontend:
- Remove setup_required decorator. This is not needed anymore since setup is taken care by before_first_app_request decorator

Changes to web_service/helpers:
- Fetch Database URL from the Database Service Name. The service names for all Kubernetes services are set as ENV variables during the web service pod deployment
- Delete pipeline helper methods: Before deleting a pipeline, check whether one or more workspaces exist for the pipeline. Delete build clones (PVCs) before deleting the pipeline PVC

Changes to web_service/jenkins:
- Pass Kube namespace to Jenkins pipeline and purge jobs